### PR TITLE
remove uninitialised nonce on plain permalink format

### DIFF
--- a/inc/client/class-budpay-request.php
+++ b/inc/client/class-budpay-request.php
@@ -76,7 +76,6 @@ class Budpay_Request {
 			$callback_url = add_query_arg(
 				array(
 					'order_id' => $order_id,
-					'_wpnonce' => $custom_nonce,
 				),
 				$this->notify_url
 			);


### PR DESCRIPTION
### PR Description

This PR remove an unused nonce from the prepared payload.

proper nonce is included [here](https://github.com/bajoski34/budpay-woo-commerce-plugin/blob/main/inc/class-budpay-payment-gateway.php#L320)
